### PR TITLE
chore(pwa): PWA init: Vite + React (TypeScript) skeleton

### DIFF
--- a/pwa/README.md
+++ b/pwa/README.md
@@ -1,6 +1,8 @@
-# PWA (Stage 2+)
+# PWA (Stage 8)
 
-Vite + React (TypeScript). Placeholder for Stage 2 (button mapping) and later; Stage 1 is backend-only.
+Vite + React (TypeScript). Placeholder until Stage 8; we do Home Assistant first (Stage 3) for phone, desktop, and Watch.
+
+**Stage:** PWA development is part of **Stage 8** (optional native apps and desktop). Phone/desktop/Watch go through HA first; this PWA is the optional standalone app or desktop experience if you’re not using the HA dashboard. See [docs/PROJECT_PLAN.md](../docs/PROJECT_PLAN.md) for the full staged plan.
 
 ## Run
 

--- a/pwa/README.md
+++ b/pwa/README.md
@@ -1,0 +1,14 @@
+# PWA (Stage 2+)
+
+Vite + React (TypeScript). Placeholder for Stage 2 (button mapping) and later; Stage 1 is backend-only.
+
+## Run
+
+From this directory:
+
+```bash
+npm install
+npm run dev
+```
+
+App at http://localhost:5173. No need to run from repo root. The dev server proxies `/api` to the backend at http://localhost:8000 when you add API calls later.

--- a/pwa/index.html
+++ b/pwa/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Chattypaws</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "chattypaws-pwa",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "~5.3.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/pwa/src/App.tsx
+++ b/pwa/src/App.tsx
@@ -1,0 +1,12 @@
+/**
+ * Chattypaws PWA — placeholder until Stage 2 (button mapping).
+ * Stage 1 is backend-only; this app will show camera + regions later.
+ */
+export default function App() {
+  return (
+    <main style={{ padding: "1rem", fontFamily: "system-ui" }}>
+      <h1>Chattypaws</h1>
+      <p>Button mapping and history will go here (Stage 2+).</p>
+    </main>
+  );
+}

--- a/pwa/src/index.css
+++ b/pwa/src/index.css
@@ -1,0 +1,6 @@
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+}

--- a/pwa/src/main.tsx
+++ b/pwa/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/pwa/tsconfig.json
+++ b/pwa/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/pwa/vite.config.ts
+++ b/pwa/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      "/api": { target: "http://localhost:8000", changeOrigin: true },
+    },
+  },
+});


### PR DESCRIPTION
closes #4 

## Description

Add the PWA so we have a runnable frontend for config, mapping, and (later) history. This PR adds only the **skeleton**: Vite + React + TypeScript, placeholder UI, and run instructions. No Stage 2 features (button mapping, camera stream) yet.

## What's in this PR

- **Package:** `pwa/package.json` — name, version `0.0.1`, scripts `dev`, `build`, `preview`; React 18, Vite 5, TypeScript 5.3.
- **Config:** `pwa/vite.config.ts` (React plugin, port 5173, `/api` proxy to backend), `pwa/tsconfig.json`, `pwa/index.html`.
- **App:** `pwa/src/main.tsx`, `pwa/src/App.tsx`, `pwa/src/index.css` — minimal placeholder (“Button mapping and history will go here (Stage 2+)”).
- **Docs:** `pwa/README.md` — what’s here, how to run from `pwa/` (`npm install`, `npm run dev`), app at http://localhost:5173.

## How to verify

- From repo root: `cd pwa && npm install && npm run dev`. Dev server starts; app loads at http://localhost:5173 with the placeholder message.
- Build: `cd pwa && npm run build` completes without errors.

## Follow-up

- **Stage 2:** Button mapping UI, camera view, and API integration (separate branch/PR).
